### PR TITLE
Added support for JBoss

### DIFF
--- a/JBoss/Dockerfile
+++ b/JBoss/Dockerfile
@@ -3,6 +3,5 @@ USER root
 MAINTAINER jrbarto@us.ibm.com
 ADD agent-config /home
 COPY ./ibm-ucd-agent.zip /home/ibm-ucd-agent.zip
-#RUN curl -k https://127.0.0.1:8442/tools/ibm-ucd-agent.zip --output /home/ibm-ucd-agent.zip
 RUN unzip /home/ibm-ucd-agent.zip -d /home
 RUN /home/ibm-ucd-agent-install/install-agent.sh < /home/agent-config

--- a/JBoss/Dockerfile
+++ b/JBoss/Dockerfile
@@ -1,0 +1,8 @@
+FROM jboss/wildfly
+USER root
+MAINTAINER jrbarto@us.ibm.com
+ADD agent-config /home
+COPY ./ibm-ucd-agent.zip /home/ibm-ucd-agent.zip
+#RUN curl -k https://127.0.0.1:8442/tools/ibm-ucd-agent.zip --output /home/ibm-ucd-agent.zip
+RUN unzip /home/ibm-ucd-agent.zip -d /home
+RUN /home/ibm-ucd-agent-install/install-agent.sh < /home/agent-config

--- a/JBoss/README.md
+++ b/JBoss/README.md
@@ -1,0 +1,26 @@
+#JBoss Demo
+
+Summary: Small docker-compose file to set up a IBM UrbanCode server, JBoss server, and an IBM UrbanCode Deploy agent.
+
+### Versions
+- Trial UrbanCode Server and Agent: v6.2.2.0.830952
+- JBoss Server: Wildfly 10
+
+### Requirements
+- Docker v1.12+
+
+### Run
+`./start`
+
+### Credentials
+- IBM UrbanCode Server - admin:admin
+
+### Sources
+- [IBM UrbanCode Server Docker Installation](https://hub.docker.com/r/ibmcom/ucds/)
+- [IBM UrbanCode Agent Docker Installation](https://hub.docker.com/r/ibmcom/ucda/)
+- [JBoss Wildfly Server Docker Installation](https://hub.docker.com/r/jboss/wildfly/)
+
+### Instructions
+You may run the 'start.sh' script to create the containers or start the cached containers if they are stopped.
+When specifying the hostname and port that jboss is running on from the UCD server, the hostname is jboss-server and the port is 8080.
+JBoss runs locally on port 8080, and the UCD server runs locally on 8081 for HTTP and 8443 for HTTPS.

--- a/JBoss/agent-config
+++ b/JBoss/agent-config
@@ -1,0 +1,12 @@
+/opt/ibm-ucd/agent
+Y
+
+N
+ucd-server
+7918
+N
+N
+N
+N
+
+

--- a/JBoss/docker-compose.yml
+++ b/JBoss/docker-compose.yml
@@ -1,0 +1,27 @@
+#
+# © Copyright IBM Corporation 2017.
+# This is licensed under the following license.
+# The Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+# U.S. Government Users Restricted Rights:  Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+#
+version: '3.3'
+services:
+    ucd-server:
+        container_name: ucd-server
+        image: ibmcom/ucds
+        ports:
+            - 8443:8443
+            - 7918:7918
+            - 8081:8080
+    jboss-image:
+        build: .
+        image: jboss/wildfly-server
+        depends_on:
+            - ucd-server
+
+    jboss-server:
+        image: jboss/wildfly-server
+        container_name: jboss-server
+        ports:
+            - 8080:8080
+            - 9990:9990

--- a/JBoss/start.sh
+++ b/JBoss/start.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+docker-compose up -d ucd-server
+docker cp ucd-server:/opt/ibm-ucd/server/opt/tomcat/webapps/ROOT/tools/ibm-ucd-agent.zip .
+
+# wait until UCD server has started
+#while ! nc -z localhost 8080;
+#  do
+#    echo sleeping;
+#    sleep 1;
+#  done;
+#echo Connected!;
+
+docker-compose build jboss-image      
+docker-compose up -d jboss-server
+docker exec jboss-server /opt/ibm-ucd/agent/bin/agent start


### PR DESCRIPTION
Created a start.sh script to create a docker container running JBoss, a
UCD server container, and install a UCD agent on the JBoss container.